### PR TITLE
Extend the universes with a Prop universe and more generic rules

### DIFF
--- a/src/checking_tactics.v
+++ b/src/checking_tactics.v
@@ -25,29 +25,9 @@ Lemma eqtype_subst_left :
     isctx G ->
     isctx D ->
     isctx E ->
-    (* istype G (Subst (Subst A sbt) sbs) -> *)
-    (* istype G (Subst A (sbcomp sbt sbs)) -> *)
     eqtype G (Subst (Subst A sbt) sbs) B.
 Proof.
   intros.
-  (* ceapply EqTyTrans. *)
-  (* - ceapply EqTySubstComp. *)
-  (*   + eassumption. *)
-  (*   + eassumption. *)
-  (*   + eassumption. *)
-  (*   + match goal with *)
-  (*     | |- ?P -> ?Q => *)
-  (*       (* match (eval cbv in P) with *) *)
-  (*       (* | config.Yes => intros _ *) *)
-  (*       (* | config.No => let H := fresh "H" in (intros H ; now elim H) *) *)
-  (*       (* | config.precondFlag => *) *)
-  (*       (*   let H := fresh "precondFlag" in intros H *) *)
-  (*       (* end *) *)
-  (*       idtac "P =" P ; *)
-  (*       match eval cbv in P with *)
-  (*       | ?H => idtac "eval cbv in H =" H *)
-  (*       end *)
-  (*     end. *)
 
   ceapply EqTyTrans ; [
     ceapply EqTySubstComp ; eassumption
@@ -69,10 +49,6 @@ Lemma eqterm_subst_left :
     isctx G ->
     isctx D ->
     isctx E ->
-    (* istype G (Subst (Subst A sbt) sbs) -> *)
-    (* istype G (Subst A (sbcomp sbt sbs)) -> *)
-    (* isterm G (subst (subst u sbt) sbs) (Subst A (sbcomp sbt sbs)) -> *)
-    (* isterm G (subst u (sbcomp sbt sbs)) (Subst A (sbcomp sbt sbs)) -> *)
     isterm G v (Subst A (sbcomp sbt sbs)) ->
     eqterm G (subst (subst u sbt) sbs) v (Subst (Subst A sbt) sbs).
 Proof.
@@ -965,7 +941,15 @@ Ltac prepushsubst1 sym :=
       | ..
       ]
     ]
-  | |- eqterm ?G (subst (uniProd ?n ?a ?b) ?sbs) _ _ =>
+  | |- eqterm ?G (subst (uniProd ?l prop ?a ?b) ?sbs) _ _ =>
+    first [
+      ceapply EqTrans ; [ ceapply EqSubstUniProdProp | .. ]
+    | ceapply EqTyConv ; [
+        ceapply EqTrans ; [ ceapply EqSubstUniProdProp | .. ]
+      | ..
+      ]
+    ]
+  | |- eqterm ?G (subst (uniProd ?n ?m ?a ?b) ?sbs) _ _ =>
     first [
       ceapply EqTrans ; [ ceapply EqSubstUniProd | .. ]
     | ceapply EqTyConv ; [
@@ -1005,7 +989,15 @@ Ltac prepushsubst1 sym :=
       | ..
       ]
     ]
-  | |- eqterm ?G (subst (uniSimProd ?n ?a ?b) ?sbs) _ _ =>
+  | |- eqterm ?G (subst (uniSimProd prop prop ?a ?b) ?sbs) _ _ =>
+    first [
+      ceapply EqTrans ; [ ceapply EqSubstUniSimProdProp | .. ]
+    | ceapply EqTyConv ; [
+        ceapply EqTrans ; [ ceapply EqSubstUniSimProdProp | .. ]
+      | ..
+      ]
+    ]
+  | |- eqterm ?G (subst (uniSimProd ?n ?m ?a ?b) ?sbs) _ _ =>
     first [
       ceapply EqTrans ; [ ceapply EqSubstUniSimProd | .. ]
     | ceapply EqTyConv ; [
@@ -1013,11 +1005,19 @@ Ltac prepushsubst1 sym :=
       | ..
       ]
     ]
-  | |- eqterm ?G (subst (uniUni ?n) ?sbs) _ _ =>
+  | |- eqterm ?G (subst (uniUni (uni ?n)) ?sbs) _ _ =>
     first [
       ceapply EqTrans ; [ ceapply EqSubstUniUni | .. ]
     | ceapply EqTyConv ; [
         ceapply EqTrans ; [ ceapply EqSubstUniUni | .. ]
+      | ..
+      ]
+    ]
+  | |- eqterm ?G (subst (uniUni prop) ?sbs) _ _ =>
+    first [
+      ceapply EqTrans ; [ ceapply EqSubstUniProp | .. ]
+    | ceapply EqTyConv ; [
+        ceapply EqTrans ; [ ceapply EqSubstUniProp | .. ]
       | ..
       ]
     ]
@@ -2314,7 +2314,13 @@ Ltac magicn try shelf tysym debug :=
       | ceapply TermTyConv ; [ ceapply TermProj2 | .. ]
       | myfail debug
       ] ; magicn try shelf true debug
-    | |- isterm ?G (uniProd ?n ?a ?b) ?T =>
+    | |- isterm ?G (uniProd ?l prop ?a ?b) ?T =>
+      first [
+        ceapply TermUniProdProp
+      | ceapply TermTyConv ; [ ceapply TermUniProdProp | .. ]
+      | myfail debug
+      ] ; magicn try shelf true debug
+    | |- isterm ?G (uniProd ?n ?m ?a ?b) ?T =>
       first [
         ceapply TermUniProd
       | ceapply TermTyConv ; [ ceapply TermUniProd | .. ]
@@ -2344,10 +2350,22 @@ Ltac magicn try shelf tysym debug :=
       | ceapply TermTyConv ; [ ceapply TermUniBool | .. ]
       | myfail debug
       ] ; magicn try shelf true debug
-    | |- isterm ?G (uniSimProd ?n ?a ?b) ?T =>
+    | |- isterm ?G (uniSimProd prop prop ?a ?b) ?T =>
+      first [
+        ceapply TermUniSimProdProp
+      | ceapply TermTyConv ; [ ceapply TermUniSimProdProp | .. ]
+      | myfail debug
+      ] ; magicn try shelf true debug
+    | |- isterm ?G (uniSimProd ?n ?m ?a ?b) ?T =>
       first [
         ceapply TermUniSimProd
       | ceapply TermTyConv ; [ ceapply TermUniSimProd | .. ]
+      | myfail debug
+      ] ; magicn try shelf true debug
+    | |- isterm ?G (uniUni prop) ?T =>
+      first [
+        ceapply TermUniProp
+      | ceapply TermTyConv ; [ ceapply TermUniProp | .. ]
       | myfail debug
       ] ; magicn try shelf true debug
     | |- isterm ?G (uniUni ?n) ?T =>
@@ -2816,7 +2834,13 @@ Ltac magicn try shelf tysym debug :=
       | ceapply EqTyConv ; [ ceapply CongProj2 | .. ]
       | myfail debug
       ] ; magicn try shelf true debug
-    | |- eqterm ?G (uniProd _ _ _) (uniProd _ _ _) _ =>
+    | |- eqterm ?G (uniProd _ prop _ _) (uniProd _ prop _ _) _ =>
+      first [
+        ceapply CongUniProdProp
+      | ceapply EqTyConv ; [ ceapply CongUniProdProp | .. ]
+      | myfail debug
+      ] ; magicn try shelf true debug
+    | |- eqterm ?G (uniProd _ _ _ _) (uniProd _ _ _ _) _ =>
       first [
         ceapply CongUniProd
       | ceapply EqTyConv ; [ ceapply CongUniProd | .. ]
@@ -2828,7 +2852,13 @@ Ltac magicn try shelf tysym debug :=
       | ceapply EqTyConv ; [ ceapply CongUniId | .. ]
       | myfail debug
       ] ; magicn try shelf true debug
-    | |- eqterm ?G (uniSimProd _ _ _) (uniSimProd _ _ _) _ =>
+    | |- eqterm ?G (uniSimProd prop prop _ _) (uniSimProd prop prop _ _) _ =>
+      first [
+        ceapply CongUniSimProdProp
+      | ceapply EqTyConv ; [ ceapply CongUniSimProdProp | .. ]
+      | myfail debug
+      ] ; magicn try shelf true debug
+    | |- eqterm ?G (uniSimProd _ _ _ _) (uniSimProd _ _ _ _) _ =>
       first [
         ceapply CongUniSimProd
       | ceapply EqTyConv ; [ ceapply CongUniSimProd | .. ]

--- a/src/checking_tactics.v
+++ b/src/checking_tactics.v
@@ -13,6 +13,7 @@ Context `{configReflection : config.Reflection}.
 Context `{configSimpleProducts : config.SimpleProducts}.
 Context `{configProdEta : config.ProdEta}.
 Context `{ConfigUniverses : config.Universes}.
+Context `{ConfigWithProp : config.WithProp}.
 
 (* Some tactic to compose substitutions. *)
 Lemma eqtype_subst_left :
@@ -133,6 +134,7 @@ Context `{configReflection : config.Reflection}.
 Context `{configSimpleProducts : config.SimpleProducts}.
 Context `{configProdEta : config.ProdEta}.
 Context `{ConfigUniverses : config.Universes}.
+Context `{ConfigWithProp : config.WithProp}.
 
 Lemma EqCompZero :
   forall {G D A u sbs},
@@ -1180,6 +1182,7 @@ Context `{configReflection : config.Reflection}.
 Context `{configSimpleProducts : config.SimpleProducts}.
 Context `{configProdEta : config.ProdEta}.
 Context `{ConfigUniverses : config.Universes}.
+Context `{ConfigWithProp : config.WithProp}.
 
 (* A lemma to do ZeroShift shifted, it not very robust as we would need
    some ZeroShift3 if ever we add a constructor that has three variables. *)

--- a/src/config.v
+++ b/src/config.v
@@ -18,7 +18,9 @@ Class Universes := {
   universesFlag : Type
 }.
 
-(* TODO: Class for Prop, or maybe even allow only one universe? *)
+Class WithProp := {
+  withpropFlag : Type
+}.
 
 Inductive Yes : Type := yes.
 Inductive No : Type := .

--- a/src/config_tactics.v
+++ b/src/config_tactics.v
@@ -18,6 +18,8 @@ Ltac doConfig :=
       let H := fresh "prodetaFlag" in intros H
     | universesFlag =>
       let H := fresh "universesFlag" in intros H
+    | withpropFlag =>
+      let H := fresh "withpropFlag" in intros H
     | _ => idtac
     end
   | |- ?P =>
@@ -29,6 +31,7 @@ Ltac doConfig :=
   | H : simpleproductsFlag |- simpleproductsFlag => exact H
   | H : prodetaFlag |- prodetaFlag => exact H
   | H : universesFlag |- universesFlag => exact H
+  | H : withpropFlag |- withpropFlag => exact H
   | _ => idtac
   end ;
   (* Configure the hypotheses *)
@@ -57,6 +60,10 @@ Ltac doConfig :=
      | @universesFlag ?F =>
        match goal with
        | R : @universesFlag F |- _ => specialize (H R)
+       end
+     | @withpropFlag ?F =>
+       match goal with
+       | R : @withpropFlag F |- _ => specialize (H R)
        end
      end
    | H : ?P |- _ =>

--- a/src/ett.v
+++ b/src/ett.v
@@ -8,6 +8,7 @@ Context `{configReflection : config.Reflection}.
 Context `{configSimpleProducts : config.SimpleProducts}.
 Context `{ConfigProdEta : config.ProdEta}.
 Context `{ConfigUniverses : config.Universes}.
+Context `{ConfigWithProp : config.WithProp}.
 
 Definition isctx := isctx.
 Definition issubst := issubst.

--- a/src/ett2ptt.v
+++ b/src/ett2ptt.v
@@ -11,6 +11,7 @@ Context `{configReflection : config.Reflection}.
 Context `{configSimpleProducts : config.SimpleProducts}.
 Context `{ConfigProdEta : config.ProdEta}.
 Context `{ConfigUniverses : config.Universes}.
+Context `{ConfigWithProp : config.WithProp}.
 
 (* Renaming ptt_sanity lemmata for readability. *)
 Definition ptt_sane_issubst := ptt_sanity.sane_issubst.

--- a/src/ett2ptt.v
+++ b/src/ett2ptt.v
@@ -348,7 +348,14 @@ Proof.
     - { capply TermUniProd.
         - now apply sane_isterm.
         - now apply sane_isterm.
-        - now apply (ptt_sane_isterm G a (Uni n)), sane_isterm.
+        - now apply (ptt_sane_isterm G a (Uni (uni n))), sane_isterm.
+      }
+
+    (* TermUniProdProp *)
+    - { capply TermUniProdProp.
+        - now apply sane_isterm.
+        - now apply sane_isterm.
+        - now apply (ptt_sane_isterm G a (Uni l)), sane_isterm.
       }
 
     (* TermUniId *)
@@ -378,11 +385,23 @@ Proof.
     - { capply TermUniSimProd.
         - now apply sane_isterm.
         - now apply sane_isterm.
-        - now apply (ptt_sane_isterm G a (Uni n)), sane_isterm.
+        - now apply (ptt_sane_isterm G a (Uni (uni n))), sane_isterm.
+      }
+
+    (* TermUniSimProdProp *)
+    - { capply TermUniSimProdProp.
+        - now apply sane_isterm.
+        - now apply sane_isterm.
+        - now apply (ptt_sane_isterm G a (Uni prop)), sane_isterm.
       }
 
     (* TermUniUni *)
     - { capply TermUniUni.
+        now apply sane_isctx.
+      }
+
+    (* TermUniProp *)
+    - { capply TermUniProp.
         now apply sane_isctx.
       }
   }
@@ -741,14 +760,21 @@ Proof.
     }
 
     (* ElProd *)
-    { config apply @ElProd with (n := n).
+    { config apply @ElProd.
       - now apply sane_isterm.
       - now apply sane_isterm.
-      - now apply (ptt_sane_isterm G a (Uni n)), sane_isterm.
+      - now apply (ptt_sane_isterm G a (Uni (uni n))), sane_isterm.
+    }
+
+    (* ElProdProp *)
+    { config apply @ElProdProp.
+      - now apply sane_isterm.
+      - now apply sane_isterm.
+      - now apply (ptt_sane_isterm G a (Uni l)), sane_isterm.
     }
 
     (* ElId *)
-    { config apply @ElId with (n := n).
+    { config apply @ElId.
       - now apply sane_isterm.
       - now apply sane_isterm.
       - now apply sane_isterm.
@@ -779,14 +805,26 @@ Proof.
     }
 
     (* ElSimProd *)
-    { config apply @ElSimProd with (n := n).
+    { config apply @ElSimProd.
       - now apply sane_isterm.
       - now apply sane_isterm.
-      - now apply (ptt_sane_isterm G a (Uni n)), sane_isterm.
+      - now apply (ptt_sane_isterm G a (Uni (uni n))), sane_isterm.
+    }
+
+    (* ElSimProdProp *)
+    { config apply @ElSimProdProp.
+      - now apply sane_isterm.
+      - now apply sane_isterm.
+      - now apply (ptt_sane_isterm G a (Uni prop)), sane_isterm.
     }
 
     (* ElUni *)
     { config apply @ElUni with (n := n).
+      now apply sane_isctx.
+    }
+
+    (* ElProp *)
+    { config apply @ElProp.
       now apply sane_isctx.
     }
 
@@ -1302,6 +1340,15 @@ Proof.
         - now apply (ptt_sane_issubst sbs G D), sane_issubst.
       }
 
+    (* EqSubstUniProdProp *)
+    - { config apply @EqSubstUniProdProp with (D := D).
+        - now apply sane_issubst.
+        - now apply sane_isterm.
+        - now apply sane_isterm.
+        - now apply (ptt_sane_issubst sbs G D), sane_issubst.
+        - now apply (ptt_sane_issubst sbs G D), sane_issubst.
+      }
+
     (* EqSubstUniId *)
     - { config apply @EqSubstUniId with (D := D).
         - now apply sane_issubst.
@@ -1342,8 +1389,24 @@ Proof.
         - now apply (ptt_sane_issubst sbs G D), sane_issubst.
       }
 
+    (* EqSubstUniSimProdProp *)
+    - { config apply @EqSubstUniSimProdProp with (D := D).
+        - now apply sane_issubst.
+        - now apply sane_isterm.
+        - now apply sane_isterm.
+        - now apply (ptt_sane_issubst sbs G D), sane_issubst.
+        - now apply (ptt_sane_issubst sbs G D), sane_issubst.
+      }
+
     (* EqSubstUniUni *)
     - { config apply @EqSubstUniUni with (D := D).
+        - now apply sane_issubst.
+        - now apply (ptt_sane_issubst sbs G D), sane_issubst.
+        - now apply (ptt_sane_issubst sbs G D), sane_issubst.
+      }
+
+    (* EqSubstUniProp *)
+    - { config apply @EqSubstUniProp with (D := D).
         - now apply sane_issubst.
         - now apply (ptt_sane_issubst sbs G D), sane_issubst.
         - now apply (ptt_sane_issubst sbs G D), sane_issubst.
@@ -1353,13 +1416,26 @@ Proof.
     - { capply CongUniProd.
         - now apply sane_eqterm.
         - now apply sane_eqterm.
-        - now apply (ptt_sane_eqterm G a1 a2 (Uni n)), sane_eqterm.
-        - now apply (ptt_sane_eqterm G a1 a2 (Uni n)), sane_eqterm.
-        - now apply (ptt_sane_eqterm (ctxextend G (El a1)) b1 b2 (Uni n)),
+        - now apply (ptt_sane_eqterm G a1 a2 (Uni (uni n))), sane_eqterm.
+        - now apply (ptt_sane_eqterm G a1 a2 (Uni (uni n))), sane_eqterm.
+        - now apply (ptt_sane_eqterm (ctxextend G (El a1)) b1 b2 (Uni (uni m))),
                     sane_eqterm.
-        - now apply (ptt_sane_eqterm (ctxextend G (El a1)) b1 b2 (Uni n)),
+        - now apply (ptt_sane_eqterm (ctxextend G (El a1)) b1 b2 (Uni (uni m))),
                     sane_eqterm.
-        - now apply (ptt_sane_eqterm G a1 a2 (Uni n)), sane_eqterm.
+        - now apply (ptt_sane_eqterm G a1 a2 (Uni (uni n))), sane_eqterm.
+      }
+
+    (* CongUniProdProp *)
+    - { capply CongUniProdProp.
+        - now apply sane_eqterm.
+        - now apply sane_eqterm.
+        - now apply (ptt_sane_eqterm G a1 a2 (Uni l)), sane_eqterm.
+        - now apply (ptt_sane_eqterm G a1 a2 (Uni l)), sane_eqterm.
+        - now apply (ptt_sane_eqterm (ctxextend G (El a1)) b1 b2 (Uni prop)),
+                    sane_eqterm.
+        - now apply (ptt_sane_eqterm (ctxextend G (El a1)) b1 b2 (Uni prop)),
+                    sane_eqterm.
+        - now apply (ptt_sane_eqterm G a1 a2 (Uni l)), sane_eqterm.
       }
 
     (* CongUniId *)
@@ -1391,11 +1467,22 @@ Proof.
     - { capply CongUniSimProd.
         - now apply sane_eqterm.
         - now apply sane_eqterm.
-        - now apply (ptt_sane_eqterm G a1 a2 (Uni n)), sane_eqterm.
-        - now apply (ptt_sane_eqterm G a1 a2 (Uni n)), sane_eqterm.
-        - now apply (ptt_sane_eqterm G b1 b2 (Uni n)), sane_eqterm.
-        - now apply (ptt_sane_eqterm G b1 b2 (Uni n)), sane_eqterm.
-        - now apply (ptt_sane_eqterm G b1 b2 (Uni n)), sane_eqterm.
+        - now apply (ptt_sane_eqterm G a1 a2 (Uni (uni n))), sane_eqterm.
+        - now apply (ptt_sane_eqterm G a1 a2 (Uni (uni n))), sane_eqterm.
+        - now apply (ptt_sane_eqterm G b1 b2 (Uni (uni m))), sane_eqterm.
+        - now apply (ptt_sane_eqterm G b1 b2 (Uni (uni m))), sane_eqterm.
+        - now apply (ptt_sane_eqterm G b1 b2 (Uni (uni m))), sane_eqterm.
+      }
+
+    (* CongUniSimProdProp *)
+    - { capply CongUniSimProdProp.
+        - now apply sane_eqterm.
+        - now apply sane_eqterm.
+        - now apply (ptt_sane_eqterm G a1 a2 (Uni prop)), sane_eqterm.
+        - now apply (ptt_sane_eqterm G a1 a2 (Uni prop)), sane_eqterm.
+        - now apply (ptt_sane_eqterm G b1 b2 (Uni prop)), sane_eqterm.
+        - now apply (ptt_sane_eqterm G b1 b2 (Uni prop)), sane_eqterm.
+        - now apply (ptt_sane_eqterm G b1 b2 (Uni prop)), sane_eqterm.
       }
   }
 

--- a/src/ett_sanity.v
+++ b/src/ett_sanity.v
@@ -18,6 +18,7 @@ Context `{configReflection : config.Reflection}.
 Context `{configSimpleProducts : config.SimpleProducts}.
 Context `{configProdEta : config.ProdEta}.
 Context `{ConfigUniverses : config.Universes}.
+Context `{ConfigWithProp : config.WithProp}.
 
 Theorem sane_issubst sbs G D :
   issubst sbs G D -> isctx G * isctx D.

--- a/src/inversion.v
+++ b/src/inversion.v
@@ -19,6 +19,7 @@ Context `{configReflection : config.Reflection}.
 Context `{configSimpleProducts : config.SimpleProducts}.
 Context `{configProdEta : config.ProdEta}.
 Context `{ConfigUniverses : config.Universes}.
+Context `{ConfigWithProp : config.WithProp}.
 
 Fixpoint TermAbsInversion {G A B u T}
          (H : ptt.isterm G (lam A B u) T) {struct H} :

--- a/src/negfunext.v
+++ b/src/negfunext.v
@@ -116,13 +116,23 @@ with trans_term (t : term) : term :=
     proj1 (trans_type A) (trans_type B) (trans_term p)
   | proj2 A B p =>
     proj2 (trans_type A) (trans_type B) (trans_term p)
-  | uniProd n a b =>
-    uniSimProd n (uniProd n (trans_term a) (trans_term b)) (uniBool n)
+  | uniProd (uni n) (uni m) a b =>
+    uniSimProd (uni (max n m)) (uni 0)
+               (uniProd (uni n) (uni m) (trans_term a) (trans_term b))
+               (uniBool 0)
+  | uniProd l prop a b =>
+    uniSimProd prop (uni 0)
+               (uniProd l prop (trans_term a) (trans_term b))
+               (uniBool 0)
+  | uniProd prop (uni n) a b =>
+    uniSimProd (uni n) (uni 0)
+               (uniProd prop (uni n) (trans_term a) (trans_term b))
+               (uniBool 0)
   | uniId n a u v => uniId n (trans_term a) (trans_term u) (trans_term v)
   | uniEmpty n => uniEmpty n
   | uniUnit n => uniUnit n
   | uniBool n => uniBool n
-  | uniSimProd n a b => uniSimProd n (trans_term a) (trans_term b)
+  | uniSimProd n m a b => uniSimProd n m (trans_term a) (trans_term b)
   | uniUni n => uniUni n
   end
 
@@ -392,11 +402,32 @@ Proof.
         }
 
       (* TermUniProd *)
-      - { simpl. capply TermUniSimProd.
-          - capply TermUniProd.
-            + now apply (trans_isterm G a (Uni n)).
-            + now apply (trans_isterm (ctxextend G (El a)) b (Uni n)).
-          - capply TermUniBool. ih.
+      - { simpl. ceapply TermTyConv.
+          - capply TermUniSimProd.
+            + capply TermUniProd.
+              * now apply (trans_isterm G a (Uni (uni n))).
+              * now apply (trans_isterm (ctxextend G (El a)) b (Uni (uni m))).
+            + capply TermUniBool. ih.
+          - assert (eq : (max (max n m) 0) = max n m).
+            { apply max_l. apply le_0_n. }
+            rewrite eq.
+            capply EqTyRefl. capply TyUni. ih.
+        }
+
+      (* TermUniProdProp *)
+      - { simpl. destruct l.
+          - capply TermUniSimProdProp.
+
+          ceapply TermTyConv.
+          - capply TermUniSimProd.
+            + capply TermUniProd.
+              * now apply (trans_isterm G a (Uni (uni n))).
+              * now apply (trans_isterm (ctxextend G (El a)) b (Uni (uni m))).
+            + capply TermUniBool. ih.
+          - assert (eq : (max (max n m) 0) = max n m).
+            { apply max_l. apply le_0_n. }
+            rewrite eq.
+            capply EqTyRefl. capply TyUni. ih.
         }
 
       (* TermUniId *)

--- a/src/negfunext.v
+++ b/src/negfunext.v
@@ -1104,11 +1104,18 @@ Proof.
       - { simpl. config apply @EqSubstUniUni with (D := trans_ctx D). ih. }
 
       (* CongUniProd *)
-      - { simpl. capply CongUniSimProd.
-          - capply CongUniProd.
-            + now apply (trans_eqterm G a1 a2 (Uni n)).
-            + now apply (trans_eqterm (ctxextend G (El a1)) b1 b2 (Uni n)).
-          - capply EqRefl. capply TermUniBool. ih.
+      - { simpl. ceapply EqTyConv.
+          - capply CongUniSimProd.
+            + capply CongUniProd.
+              * now apply (trans_eqterm G a1 a2 (Uni (uni n))).
+              * now apply (trans_eqterm (ctxextend G (El a1)) b1 b2 (Uni (uni m))).
+            + capply EqRefl. capply TermUniBool. ih.
+          - assert (eq : (max (max n m) 0) = max n m).
+            { apply max_l. apply le_0_n. }
+            rewrite eq.
+            capply EqTyRefl.
+            capply TyUni.
+            ih.
         }
 
       (* CongUniId *)
@@ -1120,8 +1127,8 @@ Proof.
 
       (* CongUniSimProd *)
       - { simpl. capply CongUniSimProd.
-          - now apply (trans_eqterm G a1 a2 (Uni n)).
-          - now apply (trans_eqterm G b1 b2 (Uni n)).
+          - now apply (trans_eqterm G a1 a2 (Uni (uni n))).
+          - now apply (trans_eqterm G b1 b2 (Uni (uni m))).
         }
     }
 

--- a/src/negfunext.v
+++ b/src/negfunext.v
@@ -22,6 +22,8 @@ Module Stt.
   Local Instance hasProdEta : config.ProdEta
     := {| config.prodetaFlag := config.No |}.
   Context `{ConfigUniverses : config.Universes}.
+  Local Instance hasProp : config.WithProp
+    := {| config.withpropFlag := config.No |}.
 
   Definition isctx   := isctx.
   Definition issubst := issubst.
@@ -49,6 +51,8 @@ Module Ttt.
   Local Instance hasProdEta : config.ProdEta
     := {| config.prodetaFlag := config.No |}.
   Context `{ConfigUniverses : config.Universes}.
+  Local Instance hasProp : config.WithProp
+    := {| config.withpropFlag := config.No |}.
 
   Definition isctx   := isctx.
   Definition issubst := issubst.
@@ -414,22 +418,6 @@ Proof.
             capply EqTyRefl. capply TyUni. ih.
         }
 
-      (* TermUniProdProp *)
-      - { simpl. destruct l.
-          - capply TermUniSimProdProp.
-
-          ceapply TermTyConv.
-          - capply TermUniSimProd.
-            + capply TermUniProd.
-              * now apply (trans_isterm G a (Uni (uni n))).
-              * now apply (trans_isterm (ctxextend G (El a)) b (Uni (uni m))).
-            + capply TermUniBool. ih.
-          - assert (eq : (max (max n m) 0) = max n m).
-            { apply max_l. apply le_0_n. }
-            rewrite eq.
-            capply EqTyRefl. capply TyUni. ih.
-        }
-
       (* TermUniId *)
       - { simpl. capply TermUniId.
           - now apply (trans_isterm G a (Uni n)).
@@ -448,8 +436,8 @@ Proof.
 
       (* TermUniSimProd *)
       - { simpl. capply TermUniSimProd.
-          - now apply (trans_isterm G a (Uni n)).
-          - now apply (trans_isterm G b (Uni n)).
+          - now apply (trans_isterm G a (Uni (uni n))).
+          - now apply (trans_isterm G b (Uni (uni m))).
         }
 
       (* TermUniUni *)
@@ -616,13 +604,13 @@ Proof.
           ceapply EqTyTrans.
           - ceapply ElSimProd.
             + capply TermUniProd.
-              * now apply (trans_isterm G a (Uni n)).
-              * now apply (trans_isterm (ctxextend G (El a)) b (Uni n)).
+              * now apply (trans_isterm G a (Uni (uni n))).
+              * now apply (trans_isterm (ctxextend G (El a)) b (Uni (uni m))).
             + capply TermUniBool. ih.
           - capply CongSimProd.
             + capply ElProd.
-              * now apply (trans_isterm G a (Uni n)).
-              * now apply (trans_isterm (ctxextend G (El a)) b (Uni n)).
+              * now apply (trans_isterm G a (Uni (uni n))).
+              * now apply (trans_isterm (ctxextend G (El a)) b (Uni (uni m))).
             + capply ElBool. ih.
         }
 
@@ -650,8 +638,8 @@ Proof.
 
       (* ElSimProd *)
       - { simpl. capply ElSimProd.
-          - now apply (trans_isterm G a (Uni n)).
-          - now apply (trans_isterm G b (Uni n)).
+          - now apply (trans_isterm G a (Uni (uni n))).
+          - now apply (trans_isterm G b (Uni (uni m))).
         }
 
       (* ElUni *)
@@ -1060,18 +1048,32 @@ Proof.
       (* EqSubstUniProd *)
       - { simpl.
           ceapply EqTrans.
-          - ceapply EqSubstUniSimProd.
-            + now apply (trans_issubst sbs G D).
-            + capply TermUniProd.
-              * now apply (trans_isterm D a (Uni n)).
-              * now apply (trans_isterm (ctxextend D (El a)) b (Uni n)).
-            + capply TermUniBool. ih.
-          - capply CongUniSimProd.
-            + config apply @EqSubstUniProd with (D := trans_ctx D).
-              * ih.
-              * now apply (trans_isterm D a (Uni n)).
-              * now apply (trans_isterm (ctxextend D (El a)) b (Uni n)).
-            + config apply @EqSubstUniBool with (D := trans_ctx D). ih.
+          - ceapply EqTyConv.
+            + ceapply EqSubstUniSimProd.
+              * now apply (trans_issubst sbs G D).
+              * capply TermUniProd.
+                -- now apply (trans_isterm D a (Uni (uni n))).
+                -- now apply (trans_isterm (ctxextend D (El a)) b (Uni (uni m))).
+              * capply TermUniBool. ih.
+            + assert (eq : (max (max n m) 0) = max n m).
+              { apply max_l. apply le_0_n. }
+              rewrite eq.
+              capply EqTyRefl.
+              capply TyUni.
+              ih.
+          - ceapply EqTyConv.
+            + capply CongUniSimProd.
+              * config apply @EqSubstUniProd with (D := trans_ctx D).
+                -- ih.
+                -- now apply (trans_isterm D a (Uni (uni n))).
+                -- now apply (trans_isterm (ctxextend D (El a)) b (Uni (uni m))).
+              * config apply @EqSubstUniBool with (D := trans_ctx D). ih.
+            + assert (eq : (max (max n m) 0) = max n m).
+              { apply max_l. apply le_0_n. }
+              rewrite eq.
+              capply EqTyRefl.
+              capply TyUni.
+              ih.
         }
 
       (* EqSubstUniId *)
@@ -1094,8 +1096,8 @@ Proof.
       (* EqSubstUniSimProd *)
       - { simpl. config apply @EqSubstUniSimProd with (D := trans_ctx D).
           - ih.
-          - now apply (trans_isterm D a (Uni n)).
-          - now apply (trans_isterm D b (Uni n)).
+          - now apply (trans_isterm D a (Uni (uni n))).
+          - now apply (trans_isterm D b (Uni (uni m))).
         }
 
       (* EqSubstUniUni *)

--- a/src/negfunext.v
+++ b/src/negfunext.v
@@ -51,8 +51,7 @@ Module Ttt.
   Local Instance hasProdEta : config.ProdEta
     := {| config.prodetaFlag := config.No |}.
   Context `{ConfigUniverses : config.Universes}.
-  Local Instance hasProp : config.WithProp
-    := {| config.withpropFlag := config.No |}.
+  Context `{ConfigWithProp : config.WithProp}.
 
   Definition isctx   := isctx.
   Definition issubst := issubst.
@@ -72,6 +71,7 @@ Section Translation.
 Context `{configReflection : config.Reflection}.
 Context `{configSimpleProducts : config.SimpleProducts}.
 Context `{ConfigUniverses : config.Universes}.
+Context `{ConfigWithProp : config.WithProp}.
 
 Fixpoint trans_type (A : type) : type :=
   match A with

--- a/src/ptt.v
+++ b/src/ptt.v
@@ -8,6 +8,7 @@ Context `{configReflection : config.Reflection}.
 Context `{configSimpleProducts : config.SimpleProducts}.
 Context `{ConfigProdEta : config.ProdEta}.
 Context `{ConfigUniverses : config.Universes}.
+Context `{ConfigWithProp : config.WithProp}.
 
 Definition isctx := isctx.
 Definition issubst := issubst.

--- a/src/ptt2ett.v
+++ b/src/ptt2ett.v
@@ -11,6 +11,7 @@ Context `{configReflection : config.Reflection}.
 Context `{configSimpleProducts : config.SimpleProducts}.
 Context `{ConfigProdEta : config.ProdEta}.
 Context `{ConfigUniverses : config.Universes}.
+Context `{ConfigWithProp : config.WithProp}.
 
 Fixpoint sane_isctx G (P : ptt.isctx G) : ett.isctx G
 

--- a/src/ptt2ett.v
+++ b/src/ptt2ett.v
@@ -157,6 +157,9 @@ Proof.
       (* TermUniProd *)
       - apply TermUniProd ; auto.
 
+      (* TermUniProdProp *)
+      - apply TermUniProdProp ; auto.
+
       (* TermUniId *)
       - apply TermUniId ; auto.
 
@@ -172,8 +175,14 @@ Proof.
       (* TermUniSimProd *)
       - apply TermUniSimProd ; auto.
 
+      (* TermUniSimProdProp *)
+      - apply TermUniSimProdProp ; auto.
+
       (* TermUniUni *)
       - apply TermUniUni ; auto.
+
+      (* TermUniProp *)
+      - apply TermUniProp ; auto.
   }
 
   (* sane_eqctx *)
@@ -304,6 +313,9 @@ Proof.
       (* ElProd *)
       - eapply ElProd ; eauto.
 
+      (* ElProdProp *)
+      - eapply ElProdProp ; eauto.
+
       (* ElId *)
       - eapply ElId ; eauto.
 
@@ -322,8 +334,14 @@ Proof.
       (* ElSimProd *)
       - eapply ElSimProd ; eauto.
 
+      (* ElSimProdProp *)
+      - eapply ElSimProdProp ; eauto.
+
       (* ElUni *)
       - apply ElUni ; auto.
+
+      (* ElProp *)
+      - apply ElProp ; auto.
 
       (* CongEl *)
       - eapply CongEl ; eauto.
@@ -469,6 +487,9 @@ Proof.
       (* EqSubstUniProd *)
       - apply @EqSubstUniProd with (D := D) ; auto.
 
+      (* EqSubstUniProdProp *)
+      - apply @EqSubstUniProdProp with (D := D) ; auto.
+
       (* EqSubstUniId *)
       - apply @EqSubstUniId with (D := D) ; auto.
 
@@ -484,17 +505,29 @@ Proof.
       (* EqSubstUniSimProd *)
       - apply @EqSubstUniSimProd with (D := D) ; auto.
 
+      (* EqSubstUniSimProdProp *)
+      - apply @EqSubstUniSimProdProp with (D := D) ; auto.
+
       (* EqSubstUniUni *)
       - apply @EqSubstUniUni with (D := D) ; auto.
 
+      (* EqSubstUniProp *)
+      - apply @EqSubstUniProp with (D := D) ; auto.
+
       (* CongUniProd *)
       - apply CongUniProd ; auto.
+
+      (* CongUniProdProp *)
+      - apply CongUniProdProp ; auto.
 
       (* CongUniId *)
       - apply CongUniId ; auto.
 
       (* CongUniSimProd *)
       - apply CongUniSimProd ; auto.
+
+      (* CongUniSimProdProp *)
+      - apply CongUniSimProdProp ; auto.
     }
 Defined.
 

--- a/src/ptt_admissible.v
+++ b/src/ptt_admissible.v
@@ -13,6 +13,7 @@ Context `{configReflection : config.Reflection}.
 Context `{configSimpleProducts : config.SimpleProducts}.
 Context `{configProdEta : config.ProdEta}.
 Context `{ConfigUniverses : config.Universes}.
+Context `{ConfigWithProp : config.WithProp}.
 
 (* Some preliminary lemmata *)
 Lemma EqTyWeakNat :

--- a/src/ptt_inversion.v
+++ b/src/ptt_inversion.v
@@ -13,6 +13,7 @@ Context `{ConfigReflection : config.Reflection}.
 Context `{configSimpleProducts : config.SimpleProducts}.
 Context `{configProdEta : config.ProdEta}.
 Context `{ConfigUniverses : config.Universes}.
+Context `{ConfigWithProp : config.WithProp}.
 
 Definition CtxExtendInversion G A (H : isctx (ctxextend G A)) :
   isctx G * istype G A.

--- a/src/ptt_sanity.v
+++ b/src/ptt_sanity.v
@@ -14,6 +14,7 @@ Context `{configReflection : config.Reflection}.
 Context `{configSimpleProducts : config.SimpleProducts}.
 Context `{ConfigProdEta : config.ProdEta}.
 Context `{ConfigUniverses : config.Universes}.
+Context `{ConfigWithProp : config.WithProp}.
 
 Axiom cheating : forall A, A.
 

--- a/src/ptt_sanity.v
+++ b/src/ptt_sanity.v
@@ -132,6 +132,9 @@ Proof.
   (* TermUniProd *)
   { magic. }
 
+  (* TermUniProdProp *)
+  { magic. }
+
   (* TermUniId *)
   { magic. }
 
@@ -147,7 +150,13 @@ Proof.
   (* TermUniSimProd *)
   { magic. }
 
+  (* TermUniSimProdProp *)
+  { magic. }
+
   (* TermUniUni *)
+  { magic. }
+
+  (* TermUniProp *)
   { magic. }
 Qed.
 
@@ -271,6 +280,12 @@ Proof.
     - magic.
   }
 
+  (* ElProdProp *)
+  { split.
+    - magic.
+    - magic.
+  }
+
   (* ElId *)
   { split.
     - magic.
@@ -307,7 +322,19 @@ Proof.
     - magic.
   }
 
+  (* ElSimProdProp *)
+  { split.
+    - magic.
+    - magic.
+  }
+
   (* ElUni *)
+  { split.
+    - magic.
+    - magic.
+  }
+
+  (* ElProp *)
   { split.
     - magic.
     - magic.
@@ -786,6 +813,13 @@ Proof.
         Unshelve. all: try apply CtxRefl. all:strictmagic.
     }
 
+  (* EqSubstUniProdProp *)
+  - { split.
+      - magic.
+      - magic.
+        Unshelve. all: try apply CtxRefl. all:strictmagic.
+    }
+
   (* EqSubstUniId *)
   - { split.
       - magic.
@@ -817,13 +851,31 @@ Proof.
       - magic.
     }
 
+  (* EqSubstUniSimProdProp *)
+  - { split.
+      - magic.
+      - magic.
+    }
+
   (* EqSubstUniUni *)
   - { split.
       - magic.
       - magic.
     }
 
+  (* EqSubstUniProp *)
+  - { split.
+      - magic.
+      - magic.
+    }
+
   (* CongUniProd *)
+  - { split.
+      - magic.
+      - magic.
+    }
+
+  (* CongUniProdProp *)
   - { split.
       - magic.
       - magic.
@@ -836,6 +888,12 @@ Proof.
     }
 
   (* CongUniSimProd *)
+  - { split.
+      - magic.
+      - magic.
+    }
+
+  (* CongUniSimProdProp *)
   - { split.
       - magic.
       - magic.

--- a/src/syntax.v
+++ b/src/syntax.v
@@ -1,3 +1,9 @@
+(* Universe levels *)
+Inductive level : Type :=
+| uni : nat -> level
+| prop : level
+.
+
 Inductive context : Type :=
      | ctxempty : context
      | ctxextend : context -> type -> context
@@ -10,8 +16,7 @@ with type : Type :=
      | Unit : type
      | Bool : type
      | SimProd : type -> type -> type
-     | Uni : nat -> type
-     (* TODO: Add a Prop universe *)
+     | Uni : level -> type
      | El : term -> type
 
 with term : Type :=
@@ -29,13 +34,13 @@ with term : Type :=
      | pair : type -> type -> term -> term -> term
      | proj1 : type -> type -> term -> term
      | proj2 : type -> type -> term -> term
-     | uniProd : nat -> term -> term -> term
-     | uniId : nat -> term -> term -> term -> term
-     | uniEmpty : nat -> term
-     | uniUnit : nat -> term
+     | uniProd : level -> level -> term -> term -> term
+     | uniId : level -> term -> term -> term -> term
+     | uniEmpty : level -> term
+     | uniUnit : level -> term
      | uniBool : nat -> term
-     | uniSimProd : nat -> term -> term -> term
-     | uniUni : nat -> term
+     | uniSimProd : level -> level -> term -> term -> term
+     | uniUni : level -> term
 
 with substitution : Type :=
      | sbzero : type -> term -> substitution

--- a/src/tt.v
+++ b/src/tt.v
@@ -11,6 +11,7 @@ Context `{ConfigReflection : config.Reflection}.
 Context `{ConfigSimpleProducts : config.SimpleProducts}.
 Context `{ConfigProdEta : config.ProdEta}.
 Context `{ConfigUniverses : config.Universes}.
+Context `{ConfigWithProp : config.WithProp}.
 
 Notation "'rule' r 'endrule'" := (r) (at level 96, only parsing).
 
@@ -25,6 +26,9 @@ Notation "'prodeta' r" :=
 
 Notation "'universe' r" :=
   (forall { _ : universesFlag }, r) (only parsing, at level 97).
+
+Notation "'withprop' r" :=
+  (forall { _ : withpropFlag }, r) (only parsing, at level 97).
 
 Notation "'parameters:'  x .. y , p" :=
   ((forall x , .. (forall y , p) ..))
@@ -453,7 +457,7 @@ with isterm : context -> term -> type -> Type :=
        endrule
 
      | TermUniProdProp :
-       universe rule
+       universe withprop rule
          parameters: {G a b l},
          premise: isterm G a (Uni l)
          premise: isterm (ctxextend G (El a)) b (Uni prop)
@@ -508,7 +512,7 @@ with isterm : context -> term -> type -> Type :=
        endrule
 
      | TermUniSimProdProp :
-       universe simpleproduct rule
+       universe withprop simpleproduct rule
          parameters: {G a b},
          premise: isterm G a (Uni prop)
          premise: isterm G b (Uni prop)
@@ -526,7 +530,7 @@ with isterm : context -> term -> type -> Type :=
        endrule
 
      | TermUniProp :
-       universe rule
+       universe withprop rule
          parameters: {G},
          premise: isctx G
          conclusion:
@@ -1059,7 +1063,7 @@ with eqtype : context -> type -> type -> Type :=
        endrule
 
      | ElProdProp :
-       universe rule
+       universe withprop rule
          parameters: {G a b l},
          premise: isterm G a (Uni l)
          premise: isterm (ctxextend G (El a)) b (Uni prop)
@@ -1139,7 +1143,7 @@ with eqtype : context -> type -> type -> Type :=
        endrule
 
      | ElSimProdProp :
-       universe simpleproduct rule
+       universe withprop simpleproduct rule
          parameters: {G a b},
          premise: isterm G a (Uni prop)
          premise: isterm G b (Uni prop)
@@ -1161,7 +1165,7 @@ with eqtype : context -> type -> type -> Type :=
        endrule
 
      | ElProp :
-       universe rule
+       universe withprop rule
          parameters: {G},
          premise: isctx G
          conclusion:
@@ -2125,7 +2129,7 @@ with eqterm : context -> term -> term -> type -> Type :=
        endrule
 
      | EqSubstUniProdProp :
-       universe rule
+       universe withprop rule
          parameters: {G D a b l sbs},
          premise: issubst sbs G D
          premise: isterm D a (Uni l)
@@ -2210,7 +2214,7 @@ with eqterm : context -> term -> term -> type -> Type :=
        endrule
 
      | EqSubstUniSimProdProp :
-       universe simpleproduct rule
+       universe withprop simpleproduct rule
          parameters: {G D a b sbs},
          premise: issubst sbs G D
          premise: isterm D a (Uni prop)
@@ -2238,7 +2242,7 @@ with eqterm : context -> term -> term -> type -> Type :=
        endrule
 
      | EqSubstUniProp :
-       universe rule
+       universe withprop rule
          parameters: {G D sbs},
          premise: issubst sbs G D
          precond: isctx G
@@ -2268,7 +2272,7 @@ with eqterm : context -> term -> term -> type -> Type :=
        endrule
 
      | CongUniProdProp :
-       universe rule
+       universe withprop rule
          parameters: {G a1 a2 b1 b2 l},
          premise: eqterm G a1 a2 (Uni l)
          premise: eqterm (ctxextend G (El a1)) b1 b2 (Uni prop)
@@ -2322,7 +2326,7 @@ with eqterm : context -> term -> term -> type -> Type :=
        endrule
 
      | CongUniSimProdProp :
-       universe simpleproduct rule
+       universe withprop simpleproduct rule
          parameters: {G a1 a2 b1 b2},
          premise: eqterm G a1 a2 (Uni prop)
          premise: eqterm G b1 b2 (Uni prop)

--- a/src/tt.v
+++ b/src/tt.v
@@ -444,12 +444,22 @@ with isterm : context -> term -> type -> Type :=
 
      | TermUniProd :
        universe rule
-         parameters: {G a b n},
-         premise: isterm G a (Uni n)
-         premise: isterm (ctxextend G (El a)) b (Uni n)
+         parameters: {G a b n m},
+         premise: isterm G a (Uni (uni n))
+         premise: isterm (ctxextend G (El a)) b (Uni (uni m))
          precond: isctx G
          conclusion:
-           isterm G (uniProd n a b) (Uni n)
+           isterm G (uniProd (uni n) (uni m) a b) (Uni (uni (max n m)))
+       endrule
+
+     | TermUniProdProp :
+       universe rule
+         parameters: {G a b l},
+         premise: isterm G a (Uni l)
+         premise: isterm (ctxextend G (El a)) b (Uni prop)
+         precond: isctx G
+         conclusion:
+           isterm G (uniProd l prop a b) (Uni prop)
        endrule
 
      | TermUniId :
@@ -484,17 +494,27 @@ with isterm : context -> term -> type -> Type :=
          parameters: {G n},
          premise: isctx G
          conclusion:
-           isterm G (uniBool n) (Uni n)
+           isterm G (uniBool n) (Uni (uni n))
        endrule
 
      | TermUniSimProd :
        universe simpleproduct rule
-         parameters: {G a b n},
-         premise: isterm G a (Uni n)
-         premise: isterm G b (Uni n)
+         parameters: {G a b n m},
+         premise: isterm G a (Uni (uni n))
+         premise: isterm G b (Uni (uni m))
          precond: isctx G
          conclusion:
-           isterm G (uniSimProd n a b) (Uni n)
+           isterm G (uniSimProd (uni n) (uni m) a b) (Uni (uni (max n m)))
+       endrule
+
+     | TermUniSimProdProp :
+       universe simpleproduct rule
+         parameters: {G a b},
+         premise: isterm G a (Uni prop)
+         premise: isterm G b (Uni prop)
+         precond: isctx G
+         conclusion:
+           isterm G (uniSimProd prop prop a b) (Uni prop)
        endrule
 
      | TermUniUni :
@@ -502,7 +522,15 @@ with isterm : context -> term -> type -> Type :=
          parameters: {G n},
          premise: isctx G
          conclusion:
-           isterm G (uniUni n) (Uni (S n))
+           isterm G (uniUni (uni n)) (Uni (uni (S n)))
+       endrule
+
+     | TermUniProp :
+       universe rule
+         parameters: {G},
+         premise: isctx G
+         conclusion:
+           isterm G (uniUni prop) (Uni (uni 0))
        endrule
 
 
@@ -1020,13 +1048,25 @@ with eqtype : context -> type -> type -> Type :=
 
      | ElProd :
        universe rule
-         parameters: {G a b n},
-         premise: isterm G a (Uni n)
-         premise: isterm (ctxextend G (El a)) b (Uni n)
+         parameters: {G a b n m},
+         premise: isterm G a (Uni (uni n))
+         premise: isterm (ctxextend G (El a)) b (Uni (uni m))
          precond: isctx G
          conclusion:
            eqtype G
-                  (El (uniProd n a b))
+                  (El (uniProd (uni n) (uni m) a b))
+                  (Prod (El a) (El b))
+       endrule
+
+     | ElProdProp :
+       universe rule
+         parameters: {G a b l},
+         premise: isterm G a (Uni l)
+         premise: isterm (ctxextend G (El a)) b (Uni prop)
+         precond: isctx G
+         conclusion:
+           eqtype G
+                  (El (uniProd l prop a b))
                   (Prod (El a) (El b))
        endrule
 
@@ -1088,13 +1128,25 @@ with eqtype : context -> type -> type -> Type :=
 
      | ElSimProd :
        universe simpleproduct rule
-         parameters: {G a b n},
-         premise: isterm G a (Uni n)
-         premise: isterm G b (Uni n)
+         parameters: {G a b n m},
+         premise: isterm G a (Uni (uni n))
+         premise: isterm G b (Uni (uni m))
          precond: isctx G
          conclusion:
            eqtype G
-                  (El (uniSimProd n a b))
+                  (El (uniSimProd (uni n) (uni m) a b))
+                  (SimProd (El a) (El b))
+       endrule
+
+     | ElSimProdProp :
+       universe simpleproduct rule
+         parameters: {G a b},
+         premise: isterm G a (Uni prop)
+         premise: isterm G b (Uni prop)
+         precond: isctx G
+         conclusion:
+           eqtype G
+                  (El (uniSimProd prop prop a b))
                   (SimProd (El a) (El b))
        endrule
 
@@ -1104,8 +1156,18 @@ with eqtype : context -> type -> type -> Type :=
          premise: isctx G
          conclusion:
            eqtype G
-                  (El (uniUni n))
-                  (Uni n)
+                  (El (uniUni (uni n)))
+                  (Uni (uni n))
+       endrule
+
+     | ElProp :
+       universe rule
+         parameters: {G},
+         premise: isctx G
+         conclusion:
+           eqtype G
+                  (El (uniUni prop))
+                  (Uni prop)
        endrule
 
      | CongEl :
@@ -2046,17 +2108,35 @@ with eqterm : context -> term -> term -> type -> Type :=
 
      | EqSubstUniProd :
        universe rule
-         parameters: {G D a b n sbs},
+         parameters: {G D a b n m sbs},
          premise: issubst sbs G D
-         premise: isterm D a (Uni n)
-         premise: isterm (ctxextend D (El a)) b (Uni n)
+         premise: isterm D a (Uni (uni n))
+         premise: isterm (ctxextend D (El a)) b (Uni (uni m))
          precond: isctx G
          precond: isctx D
          conclusion:
            eqterm G
-                  (subst (uniProd n a b) sbs)
-                  (uniProd n (subst a sbs) (subst b (sbshift (El a) sbs)))
-                  (Uni n)
+                  (subst (uniProd (uni n) (uni m) a b) sbs)
+                  (uniProd (uni n)
+                           (uni m)
+                           (subst a sbs)
+                           (subst b (sbshift (El a) sbs)))
+                  (Uni (uni (max n m)))
+       endrule
+
+     | EqSubstUniProdProp :
+       universe rule
+         parameters: {G D a b l sbs},
+         premise: issubst sbs G D
+         premise: isterm D a (Uni l)
+         premise: isterm (ctxextend D (El a)) b (Uni prop)
+         precond: isctx G
+         precond: isctx D
+         conclusion:
+           eqterm G
+                  (subst (uniProd l prop a b) sbs)
+                  (uniProd l prop (subst a sbs) (subst b (sbshift (El a) sbs)))
+                  (Uni prop)
        endrule
 
      | EqSubstUniId :
@@ -2111,22 +2191,37 @@ with eqterm : context -> term -> term -> type -> Type :=
            eqterm G
                   (subst (uniBool n) sbs)
                   (uniBool n)
-                  (Uni n)
+                  (Uni (uni n))
        endrule
 
      | EqSubstUniSimProd :
        universe simpleproduct rule
-         parameters: {G D a b n sbs},
+         parameters: {G D a b n m sbs},
          premise: issubst sbs G D
-         premise: isterm D a (Uni n)
-         premise: isterm D b (Uni n)
+         premise: isterm D a (Uni (uni n))
+         premise: isterm D b (Uni (uni m))
          precond: isctx G
          precond: isctx D
          conclusion:
            eqterm G
-                  (subst (uniSimProd n a b) sbs)
-                  (uniSimProd n (subst a sbs) (subst b sbs))
-                  (Uni n)
+                  (subst (uniSimProd (uni n) (uni m) a b) sbs)
+                  (uniSimProd (uni n) (uni m) (subst a sbs) (subst b sbs))
+                  (Uni (uni (max n m)))
+       endrule
+
+     | EqSubstUniSimProdProp :
+       universe simpleproduct rule
+         parameters: {G D a b sbs},
+         premise: issubst sbs G D
+         premise: isterm D a (Uni prop)
+         premise: isterm D b (Uni prop)
+         precond: isctx G
+         precond: isctx D
+         conclusion:
+           eqterm G
+                  (subst (uniSimProd prop prop a b) sbs)
+                  (uniSimProd prop prop (subst a sbs) (subst b sbs))
+                  (Uni prop)
        endrule
 
      | EqSubstUniUni :
@@ -2137,26 +2232,56 @@ with eqterm : context -> term -> term -> type -> Type :=
          precond: isctx D
          conclusion:
            eqterm G
-                  (subst (uniUni n) sbs)
-                  (uniUni n)
-                  (Uni (S n))
+                  (subst (uniUni (uni n)) sbs)
+                  (uniUni (uni n))
+                  (Uni (uni (S n)))
+       endrule
+
+     | EqSubstUniProp :
+       universe rule
+         parameters: {G D sbs},
+         premise: issubst sbs G D
+         precond: isctx G
+         precond: isctx D
+         conclusion:
+           eqterm G
+                  (subst (uniUni prop) sbs)
+                  (uniUni prop)
+                  (Uni (uni 0))
        endrule
 
      | CongUniProd :
        universe rule
-         parameters: {G a1 a2 b1 b2 n},
-         premise: eqterm G a1 a2 (Uni n)
-         premise: eqterm (ctxextend G (El a1)) b1 b2 (Uni n)
-         precond: isterm G a1 (Uni n)
-         precond: isterm G a2 (Uni n)
-         precond: isterm (ctxextend G (El a1)) b1 (Uni n)
-         precond: isterm (ctxextend G (El a1)) b2 (Uni n)
+         parameters: {G a1 a2 b1 b2 n m},
+         premise: eqterm G a1 a2 (Uni (uni n))
+         premise: eqterm (ctxextend G (El a1)) b1 b2 (Uni (uni m))
+         precond: isterm G a1 (Uni (uni n))
+         precond: isterm G a2 (Uni (uni n))
+         precond: isterm (ctxextend G (El a1)) b1 (Uni (uni m))
+         precond: isterm (ctxextend G (El a1)) b2 (Uni (uni m))
          precond: isctx G
          conclusion:
            eqterm G
-                  (uniProd n a1 b1)
-                  (uniProd n a2 b2)
-                  (Uni n)
+                  (uniProd (uni n) (uni m) a1 b1)
+                  (uniProd (uni n) (uni m) a2 b2)
+                  (Uni (uni (max n m)))
+       endrule
+
+     | CongUniProdProp :
+       universe rule
+         parameters: {G a1 a2 b1 b2 l},
+         premise: eqterm G a1 a2 (Uni l)
+         premise: eqterm (ctxextend G (El a1)) b1 b2 (Uni prop)
+         precond: isterm G a1 (Uni l)
+         precond: isterm G a2 (Uni l)
+         precond: isterm (ctxextend G (El a1)) b1 (Uni prop)
+         precond: isterm (ctxextend G (El a1)) b2 (Uni prop)
+         precond: isctx G
+         conclusion:
+           eqterm G
+                  (uniProd l prop a1 b1)
+                  (uniProd l prop a2 b2)
+                  (Uni prop)
        endrule
 
      | CongUniId :
@@ -2181,19 +2306,36 @@ with eqterm : context -> term -> term -> type -> Type :=
 
      | CongUniSimProd :
        universe simpleproduct rule
-         parameters: {G a1 a2 b1 b2 n},
-         premise: eqterm G a1 a2 (Uni n)
-         premise: eqterm G b1 b2 (Uni n)
-         precond: isterm G a1 (Uni n)
-         precond: isterm G a2 (Uni n)
-         precond: isterm G b1 (Uni n)
-         precond: isterm G b2 (Uni n)
+         parameters: {G a1 a2 b1 b2 n m},
+         premise: eqterm G a1 a2 (Uni (uni n))
+         premise: eqterm G b1 b2 (Uni (uni m))
+         precond: isterm G a1 (Uni (uni n))
+         precond: isterm G a2 (Uni (uni n))
+         precond: isterm G b1 (Uni (uni m))
+         precond: isterm G b2 (Uni (uni m))
          precond: isctx G
          conclusion:
            eqterm G
-                  (uniSimProd n a1 b1)
-                  (uniSimProd n a2 b2)
-                  (Uni n)
+                  (uniSimProd (uni n) (uni m) a1 b1)
+                  (uniSimProd (uni n) (uni m) a2 b2)
+                  (Uni (uni (max n m)))
+       endrule
+
+     | CongUniSimProdProp :
+       universe simpleproduct rule
+         parameters: {G a1 a2 b1 b2},
+         premise: eqterm G a1 a2 (Uni prop)
+         premise: eqterm G b1 b2 (Uni prop)
+         precond: isterm G a1 (Uni prop)
+         precond: isterm G a2 (Uni prop)
+         precond: isterm G b1 (Uni prop)
+         precond: isterm G b2 (Uni prop)
+         precond: isctx G
+         conclusion:
+           eqterm G
+                  (uniSimProd prop prop a1 b1)
+                  (uniSimProd prop prop a2 b2)
+                  (Uni prop)
        endrule
 .
 

--- a/src/uniqueness.v
+++ b/src/uniqueness.v
@@ -18,6 +18,7 @@ Context `{configReflection : config.Reflection}.
 Context `{configSimpleProducts : config.SimpleProducts}.
 Context `{configProdEta : config.ProdEta}.
 Context `{ConfigUniverses : config.Universes}.
+Context `{ConfigWithProp : config.WithProp}.
 
 (* Auxiliary inversion lemmas. *)
 

--- a/src/uniqueness.v
+++ b/src/uniqueness.v
@@ -476,10 +476,20 @@ Proof.
           - doTyConv unique_term'.
           - doCtxConv D' unique_term'.
 
-          - { apply unique_term_ctx' with (u := a) (D := D').
-              - assumption.
-              - hyp.
-              - hyp.
+          - { capply EqTyRefl.
+              capply TyUni.
+              hyp.
+            }
+        }
+
+      (* TermUniProdProp *)
+      - { inversion_clear H2' ; doConfig.
+          - doTyConv unique_term'.
+          - doCtxConv D' unique_term'.
+
+          - { capply EqTyRefl.
+              capply TyUni.
+              hyp.
             }
         }
 
@@ -488,10 +498,9 @@ Proof.
           - doTyConv unique_term'.
           - doCtxConv D' unique_term'.
 
-          - { apply unique_term_ctx' with (u := a) (D := D').
-              - assumption.
-              - hyp.
-              - hyp.
+          - { capply EqTyRefl.
+              capply TyUni.
+              hyp.
             }
         }
 
@@ -533,14 +542,35 @@ Proof.
           - doTyConv unique_term'.
           - doCtxConv D' unique_term'.
 
-          - { apply unique_term_ctx' with (u := a) (D := D').
-              - assumption.
-              - hyp.
-              - hyp.
+          - { capply EqTyRefl.
+              capply TyUni.
+              hyp.
+            }
+        }
+
+      (* TermUniSimProdProp *)
+      - { inversion_clear H2' ; doConfig.
+          - doTyConv unique_term'.
+          - doCtxConv D' unique_term'.
+
+          - { capply EqTyRefl.
+              capply TyUni.
+              hyp.
             }
         }
 
       (* TermUniUni *)
+      - { inversion_clear H2' ; doConfig.
+          - doTyConv unique_term'.
+          - doCtxConv D' unique_term'.
+
+          - { capply EqTyRefl.
+              capply TyUni.
+              hyp.
+            }
+        }
+
+      (* TermUniProp *)
       - { inversion_clear H2' ; doConfig.
           - doTyConv unique_term'.
           - doCtxConv D' unique_term'.


### PR DESCRIPTION
I change the notion of universe to have `Uni` depend on a level that can either be a natural number index or `prop` that is used to talk about the predicative `Prop` universe.

I still need to update uniqueness and negfunext.