### PR TITLE
Add substitution sbterminal

### DIFF
--- a/latex/coq2latex.py
+++ b/latex/coq2latex.py
@@ -54,6 +54,7 @@ macros = {
     'sbshift' : (2, 'sbshift'),
     'sbid' : (0, 'sbid'),
     'sbcomp' : (2, 'sbcomp'),
+    'sbterminal' : (0, 'sbterminal'),
 
     # Contexts
     'ctxempty' : (0, 'ctxempty'),

--- a/latex/macros.tex
+++ b/latex/macros.tex
@@ -29,6 +29,7 @@
 \newcommand{\sbshift}[2]{(#2 {\mid} #1)}   % shifted substitution
 \newcommand{\sbid}{\mathsf{id}}          % identity substitution
 \newcommand{\sbcomp}[2]{#1 \circ #2}     % composition of substitutions
+\newcommand{\sbterminal}{\triangleright} % terminal substitution
 
 %% Contexts
 \newcommand{\ctxempty}{\bullet} % empty context

--- a/latex/presyntax.tex
+++ b/latex/presyntax.tex
@@ -49,6 +49,7 @@
  & \sbshift{\sigma}{A} &&\text{shift substitution} \\
  & \sbid &&\text{identity substitution} \\
  & \sbcomp{\sigma}{\rho} &&\text{composition} \\
+ & \sbterminal &&\text{terminal substitition} \\
 %
 \intertext{Abbreviations:}
 %

--- a/src/annotated_syntax.v
+++ b/src/annotated_syntax.v
@@ -53,6 +53,7 @@ with substitution : Type :=
      | sbshift : type -> substitution -> substitution
      | sbid : substitution
      | sbcomp : substitution -> substitution -> substitution
+     | sbterminal : substitution
 .
 
 Local Instance Syntax : syntax.Syntax := {|
@@ -96,11 +97,12 @@ Local Instance Syntax : syntax.Syntax := {|
   syntax.uniBinaryProd := uniBinaryProd ;
   syntax.uniUni     := uniUni ;
 
-  syntax.sbzero  := sbzero ;
-  syntax.sbweak  := sbweak ;
-  syntax.sbshift := sbshift ;
-  syntax.sbid    := sbid ;
-  syntax.sbcomp  := sbcomp
+  syntax.sbzero     := sbzero ;
+  syntax.sbweak     := sbweak ;
+  syntax.sbshift    := sbshift ;
+  syntax.sbid       := sbid ;
+  syntax.sbcomp     := sbcomp ;
+  syntax.sbterminal := sbterminal
 |}.
 
 End AnnotatedSyntax.

--- a/src/annotated_uniqueness.v
+++ b/src/annotated_uniqueness.v
@@ -656,6 +656,12 @@ Proof.
        - doSubstConv unique_subst'.
      }
 
+   (* H1: SubstTerminal *)
+   - { inversion_clear H2' ; doConfig.
+       - capply EqCtxEmpty.
+       - doSubstConv unique_subst'.
+     }
+
    (* H1: SubstCtxConv *)
    - config eapply @CtxTrans with (D := D1).
      + ceapply CtxSym. hyp.

--- a/src/checking_tactics.v
+++ b/src/checking_tactics.v
@@ -2196,6 +2196,11 @@ Ltac magicn try shelf tysym debug :=
         ceapply SubstComp
       | myfail debug
       ] ; magicn try shelf DoTysym debug
+    | |- issubst sbterminal ?G1 ?G2 =>
+      first [
+        ceapply SubstTerminal
+      | myfail debug
+      ] ; magicn try shelf DoTysym debug
     | |- issubst ?sbs ?G1 ?G2 =>
       tryif (is_var sbs) then (
         first [

--- a/src/concise_syntax.v
+++ b/src/concise_syntax.v
@@ -46,6 +46,7 @@ with substitution : Type :=
      | sbshift : term -> substitution -> substitution
      | sbid : substitution
      | sbcomp : substitution -> substitution -> substitution
+     | sbterminal : substitution
 .
 
 Local Instance Syntax : syntax.Syntax := {|
@@ -89,11 +90,12 @@ Local Instance Syntax : syntax.Syntax := {|
   syntax.uniBinaryProd i j A B := BinaryProd A B ;
   syntax.uniUni i              := Uni i ;
 
-  syntax.sbzero  := sbzero ;
-  syntax.sbweak  := sbweak ;
-  syntax.sbshift := sbshift ;
-  syntax.sbid    := sbid ;
-  syntax.sbcomp  := sbcomp
+  syntax.sbzero     := sbzero ;
+  syntax.sbweak     := sbweak ;
+  syntax.sbshift    := sbshift ;
+  syntax.sbid       := sbid ;
+  syntax.sbcomp     := sbcomp ;
+  syntax.sbterminal := sbterminal
 |}.
 
 End ConciseSyntax.

--- a/src/ett2ptt.v
+++ b/src/ett2ptt.v
@@ -124,6 +124,11 @@ Proof.
            now apply sane_issubst.
        }
 
+     (* SubstTerminal *)
+     - { capply SubstTerminal.
+         now apply sane_isctx.
+       }
+
      (* SubstCtxConv *)
      - {
          config apply @SubstCtxConv with (G1 := G1) (D1 := D1).

--- a/src/forget_annotation.v
+++ b/src/forget_annotation.v
@@ -163,6 +163,7 @@ with forget_subst (sbs : Att.substitution) : Ctt.substitution :=
   | A.sbshift A sbs => C.sbshift (forget_type A) (forget_subst sbs)
   | A.sbid => C.sbid
   | A.sbcomp sbs sbt => C.sbcomp (forget_subst sbs) (forget_subst sbt)
+  | A.sbterminal => C.sbterminal
   end.
 
 Axiom admit : forall {A}, A.
@@ -610,6 +611,8 @@ Proof.
       (* SubstComp *)
       - { simpl. (config apply @SubstComp with (D := forget_ctx D)) ; ih. }
 
+      (* SubstTerminal *)
+      - { simpl. capply @SubstTerminal ; ih. }
 
       (* SubstCtxConv *)
       - { (config apply @SubstCtxConv with (G1 := forget_ctx G1) (D1 := forget_ctx D1)) ; ih. }

--- a/src/negfunext.v
+++ b/src/negfunext.v
@@ -168,6 +168,7 @@ with trans_subst (sbs : substitution) : substitution :=
   | sbshift A sbs => sbshift (trans_type A) (trans_subst sbs)
   | sbid => sbid
   | sbcomp sbs sbt => sbcomp (trans_subst sbs) (trans_subst sbt)
+  | sbterminal => sbterminal
   end.
 
 Fixpoint trans_ctx (G : context) : context :=
@@ -483,6 +484,9 @@ Proof.
           - ih.
           - ih.
         }
+
+      (* SubstTerminal *)
+      - { simpl. capply @SubstTerminal. ih. }
 
       (* SubstCtxConv *)
       - { config apply @SubstCtxConv with (G1 := trans_ctx G1) (D1 := trans_ctx D1).

--- a/src/ptt2ett.v
+++ b/src/ptt2ett.v
@@ -70,6 +70,9 @@ Proof.
       (* SubstComp *)
        - { config apply @SubstComp with (D := D) ; auto. }
 
+       (* SubstTerminal *)
+       - { capply SubstTerminal ; auto. }
+
       (* SubstCtxConv *)
       - { config apply @SubstCtxConv with (G1 := G1) (D1 := D1) ; auto. }
   }

--- a/src/ptt_sanity.v
+++ b/src/ptt_sanity.v
@@ -63,6 +63,12 @@ Proof.
     - assumption.
   }
 
+  (* SubstTerminal *)
+  { split.
+    - assumption.
+    - magic.
+  }
+
   (* SubstCtxConv *)
   { split.
     - assumption.

--- a/src/syntax.v
+++ b/src/syntax.v
@@ -50,6 +50,7 @@ Class Syntax := {
   sbshift : type -> substitution -> substitution;
   sbid : substitution;
   sbcomp : substitution -> substitution -> substitution;
+  sbterminal : substitution;
 
   Arrow := (fun (A B :  type) => Prod A (Subst B (sbweak A)))
 }.

--- a/src/tt.v
+++ b/src/tt.v
@@ -141,6 +141,13 @@ with issubst : substitution -> context -> context -> Type :=
            issubst (sbcomp sbt sbs) G E
        endrule
 
+     | SubstTerminal :
+       rule
+         parameters: {G},
+         premise: isctx G
+         conclusion: issubst sbterminal G ctxempty
+       endrule
+
      | SubstCtxConv :
        rule
          parameters: {G1 G2 D1 D2 sbs},


### PR DESCRIPTION
I added `sbterminal` as a primitive substitution and updated the proofs accordingly.
I guess we still need to update the latex part before merging (edit: **done**).